### PR TITLE
Fixed exporting code

### DIFF
--- a/client/components/navbar/navbar.js
+++ b/client/components/navbar/navbar.js
@@ -39,7 +39,7 @@ class MainNav extends React.Component {
     const tables = this.props.tables; 
     const changedTables = []
     for (let tableId in tables) {
-      const changedFields = []
+      const changedFields = {}
       for (let fieldId in tables[tableId].fields) {
         const field = tables[tableId].fields[fieldId];
         const refBy = field.refBy
@@ -48,10 +48,10 @@ class MainNav extends React.Component {
           refBy.forEach(ele => {
             refByArray.push(ele);
           })
-          changedFields.push(Object.assign({}, field, { 'refBy': refByArray }))
+          changedFields[fieldId] = (Object.assign({}, field, { 'refBy': refByArray }))
         }
       }
-      if (changedFields.length > 0) {
+      if (Object.keys(changedFields).length > 0) {
         const fields = Object.assign({}, tables[tableId].fields, changedFields)
         changedTables.push(Object.assign({}, tables[tableId], { 'fields': fields }))
       }

--- a/client/components/schema/sidebar/table-options.js
+++ b/client/components/schema/sidebar/table-options.js
@@ -330,7 +330,7 @@ class TableOptions extends React.Component {
                     <MenuItem value='one to one' primaryText="one to one" />
                     <MenuItem value='one to many' primaryText="one to many" />
                     <MenuItem value='many to one' primaryText="many to one" />
-                    <MenuItem value='many to many' primaryText="many to many" />
+                    {/* <MenuItem value='many to many' primaryText="many to many" /> */}
                   </DropDownMenu>
                 </div>
               </span>)}

--- a/client/components/welcome/welcome.js
+++ b/client/components/welcome/welcome.js
@@ -75,9 +75,9 @@ class Welcome extends React.Component {
             <RaisedButton onClick={this.handleDatabaseClick} buttonStyle={styles}>
               MySQL
             </RaisedButton>
-            <RaisedButton onClick={this.handleDatabaseClick} buttonStyle={styles}>
+            {/* <RaisedButton onClick={this.handleDatabaseClick} buttonStyle={styles}>
               PostgreSQL
-              </RaisedButton>
+            </RaisedButton> */}
           </div>
         </Dialog>
       </div>

--- a/server/create_file_func/client_mutations.js
+++ b/server/create_file_func/client_mutations.js
@@ -1,3 +1,5 @@
+const tab = `  `
+
 function parseClientMutations(tables) {
   let query = "import { gql } from \'apollo-boost\';\n\n";
   const exportNames = [];
@@ -27,11 +29,9 @@ function parseClientMutations(tables) {
   let endString = `export {\n`;
   exportNames.forEach((name, i) => {
     if (i === 0) {
-      endString += `\t${name},\n`;
-    } else if (i < exportNames.length - 1) {
-      endString += `\t${name},\n`;
+      endString += `${tab}${name},\n`;
     } else {
-      endString += tab + name + enter;
+      endString += `${tab}${name},\n`;
     }
   });
 
@@ -40,7 +40,7 @@ function parseClientMutations(tables) {
 
 // builds params for either add or update mutations
 function buildMutationParams(table, mutationType) {
-  let query = `const ${mutationType}${table.type}Mutation = gql\`\n\tmutation(`;
+  let query = `const ${mutationType}${table.type}Mutation = gql\`\n${tab}mutation(`;
 
   let firstLoop = true;
   for (const fieldId in table.fields) {
@@ -59,14 +59,14 @@ function buildMutationParams(table, mutationType) {
       query += `${checkForRequired(table.fields[fieldId].required)}`;
     }
   }
-  return query += `) {\n\t`;
+  return query += `) {\n${tab}`;
 }
 
 function buildDeleteMutationParams(table) {
   const idName = table.fields[0].name;
   let query = `const delete${table.type}Mutation = gpq\`\n`
-     query += `\tmutation($${idName}: ID!){\n`
-     query += `\t\tdelete${table.type}(${idName}: $${idName}){\n`
+     query += `${tab}mutation($${idName}: ID!){\n`
+     query += `${tab}${tab}delete${table.type}(${idName}: $${idName}){\n`
   return query; 
 }
 
@@ -88,7 +88,7 @@ function checkForRequired(required) {
 }
 
 function buildTypeParams(table, mutationType) {
-  let query = `\t${mutationType}${table.type}(`;
+  let query = `${tab}${mutationType}${table.type}(`;
 
   let firstLoop = true;
   for (const fieldId in table.fields) {
@@ -106,10 +106,10 @@ function buildReturnValues(table) {
   let query = '';
 
   for (const fieldId in table.fields) {
-    query += `\t\t\t${table.fields[fieldId].name}\n`;
+    query += `${tab}${tab}${tab}${table.fields[fieldId].name}\n`;
   }
 
-  return query += `\t\t}\n\t}\n\`\n\n`;
+  return query += `${tab}${tab}}\n${tab}}\n\`\n\n`;
 }
 
 module.exports = parseClientMutations;

--- a/server/create_file_func/client_queries.js
+++ b/server/create_file_func/client_queries.js
@@ -1,3 +1,5 @@
+const tab = `  `
+
 function parseClientQueries(tables) {
   let query = "import { gql } from \'apollo-boost\';\n\n";
   const exportNames = [];
@@ -27,14 +29,14 @@ function parseClientQueries(tables) {
 
 function buildClientQueryAll(table) {
   let string = `const queryEvery${table.type} = gql\`\n`
-  string += `\t{\n`
-  string += `\t\tevery${toTitleCase(table.type)} {\n`;
+  string += `${tab}{\n`
+  string += `${tab}${tab}every${toTitleCase(table.type)} {\n`;
 
   for (const fieldId in table.fields) {
-    string += `\t\t\t${table.fields[fieldId].name}\n`;
+    string += `${tab}${tab}${tab}${table.fields[fieldId].name}\n`;
   }
 
-  return string += `\t\t}\n\t}\n\`\n\n`;
+  return string += `${tab}${tab}}\n${tab}}\n\`\n\n`;
 }
 
 function toTitleCase(refTypeName) {
@@ -45,14 +47,14 @@ function toTitleCase(refTypeName) {
 
 function buildClientQueryById(table) {
   let string = `const query${table.type}ById = gql\`\n`
-  string += `\tquery(${table.type}: ID) {\n`
-  string += `\t\t${table.type}(${table.type}: ${table.type}) {\n`;
+  string += `${tab}query(${table.type}: ID) {\n`
+  string += `${tab}${tab}${table.type}(${table.type}: ${table.type}) {\n`;
   
   for (const fieldId in table.fields) {
-    string += `\t\t\t${table.fields[fieldId].name}\n`;
+    string += `${tab}${tab}${tab}${table.fields[fieldId].name}\n`;
   }
 
-  return string += `\t\t}\n\t}\n\`\n\n`;
+  return string += `${tab}${tab}}\n${tab}}\n\`\n\n`;
 }
 
 module.exports = parseClientQueries;

--- a/server/create_file_func/express_server.js
+++ b/server/create_file_func/express_server.js
@@ -18,12 +18,12 @@ query += `
 app.use(express.static(path.join(__dirname, './public')))
 
 app.use('/graphql', graphqlHTTP({
-    GQLSchema,
-    graphiql: false //Set to true to view GraphiQl in browser at /graphql
+  GQLSchema,
+  graphiql: false //Set to true to view GraphiQl in browser at /graphql
 }));
 
 app.listen(4000, () => {
-    console.log('Listening on 4000')
+  console.log('Listening on 4000')
 });
 `;
   return query;

--- a/server/create_file_func/mongo_schema.js
+++ b/server/create_file_func/mongo_schema.js
@@ -1,28 +1,29 @@
 function parseMongoschema(data, cb) {
-    let query = `const mongoose = require('mongoose');\nconst Schema = mongoose.Schema;\n\nconst ${data.type.toLowerCase()}Schema = new Schema({\n\t`
+  const tab = `  `
+  let query = `const mongoose = require('mongoose');\nconst Schema = mongoose.Schema;\n\nconst ${data.type.toLowerCase()}Schema = new Schema({\n${tab}`
 
-    let firstLoop = true;
-    for (let prop in data.fields) {
-        if (prop !== '0') {
-            if (!firstLoop) query += ',\n\t'
-            firstLoop = false
-    
-            query += createSchemaField(data.fields[prop]);
-        }
+  let firstLoop = true;
+  for (let prop in data.fields) {
+    if (prop !== '0') {
+      if (!firstLoop) query += `,\n${tab}`
+      firstLoop = false
+      query += createSchemaField(data.fields[prop]);
     }
+  }
   query += `\n});\n\nmodule.exports = mongoose.model("${data.type}", ${data.type.toLowerCase()}Schema);`;
 
-  return
+  return query; 
 }
 
 function createSchemaField(data) {
-  let query = `${data.name}: ${checkForArray('start')}{\n\t\ttype: ${checkDataType(data.type)},\n\t\tunique: ${data.unique},\n\t\trequired: ${data.required}`;
+  const tab = `  `;
+  let query = `${data.name}: ${checkForArray('start')}{\n${tab}${tab}type: ${checkDataType(data.type)},\n${tab}${tab}unique: ${data.unique},\n${tab}${tab}required: ${data.required}`;
 
   if (data.defaultValue) {
-    query += `,\n\t\tdefault: "${data.defaultValue}"`;
+    query += `,\n${tab}${tab}default: "${data.defaultValue}"`;
   }
 
-  return query += `\n\t}${checkForArray('end')}`;
+  return query += `\n${tab}}${checkForArray('end')}`;
 
   function checkForArray(position) {
     if (data.multipleValues) {

--- a/server/create_file_func/mysql_pool.js
+++ b/server/create_file_func/mysql_pool.js
@@ -13,10 +13,10 @@ database: "mydb"
 })
 
 const getConnection = function(callback) {
-    pool.getConnection(function(err, con) {
-        if (err) return callback(err);
-        callback(err, con);
-    });
+  pool.getConnection(function(err, con) {
+    if (err) return callback(err);
+    callback(err, con);
+  });
 };
 
 module.exports = getConnection;

--- a/server/create_file_func/mysql_scripts.js
+++ b/server/create_file_func/mysql_scripts.js
@@ -2,7 +2,9 @@
 function parseSQLTables(tables) {
   const foreignKeys = {};
   let primaryKey = [];
-  for (const tableId in props.tables) {
+  let createTablesCode = ``;
+  let tab = `  `
+  for (const tableId in tables) {
     parseSQLTable(tables[tableId]);
   }
 
@@ -15,16 +17,16 @@ function parseSQLTables(tables) {
     for (const fieldId in table.fields) {
       createTablesCode += createTableField(table.fields[fieldId]);
       // so long as it's not the last field, add a comma
-      const tableProps = Object.keys(table.fields);
-      if (fieldId !== tableProps[tableProps.length - 1]) {
+      const fieldIds = Object.keys(table.fields);
+      if (fieldId !== fieldIds[fieldIds.length - 1]) {
         createTablesCode += `,`;
       }
-      createTablesCode += enter; 
+      createTablesCode += `\n`; 
     }
     
     // if table has a primary key
     if (primaryKey.length > 0) {
-      createTablesCode += `\tPRIMARY KEY (`;
+      createTablesCode += `${tab}PRIMARY KEY (`;
       primaryKey.forEach((key, i) => {
         if (i === primaryKey.length - 1) {
           createTablesCode += `\`${key}\`)\n`;
@@ -32,94 +34,92 @@ function parseSQLTables(tables) {
           createTablesCode += `\`${key}\`, `;
         }
       });
+      createTablesCode;
     }
-  // reset primaryKey to empty so primary keys don't slip into the next table
-  primaryKey = [];
-  createTablesCode += `);\n`;
-}
-function createTableField(field) {
-  let fieldCode = ``;
-  fieldCode += `\t\`${field.name}\`\t${checkDataType(field.type)}`;
-  fieldCode += checkAutoIncrement(field.autoIncrement);
-  fieldCode += checkRequired(field.required);
-  fieldCode += checkUnique(field.unique);
-  fieldCode += checkDefault(field.defaultValue);
-  
-  if (field.primaryKey) {
-    primaryKey.push(field.name);
+    // reset primaryKey to empty so primary keys don't slip into the next table
+    primaryKey = [];
+    createTablesCode += `);\n`;
   }
-  
-  if (field.relationSelected) {
-    const relationData = {
-      'relatedTable': field.relation.tableIndex,
-      'relatedField': field.relation.fieldIndex,
-      'fieldMakingRelation': field.fieldNum
-    };
-    if (foreignKeys[field.tableNum]) {
-      foreignKeys[field.tableNum].push(relationData);
-    } else {
-      foreignKeys[field.tableNum] = [relationData];
-    }
-  }
-  return fieldCode;
-}
-
-function checkDataType(dataType) {
-  switch(dataType){
-    case 'String':
-    return `VARCHAR`;
-    case 'Number':
-    return `INT`;
-    case 'Boolean':
-    return `BOOLEAN`;
-    case 'ID':
-    return `VARCHAR`;
-  }
-}
-
-function checkAutoIncrement(fieldAutoIncrement) {
-  if (fieldAutoIncrement) return `\tAUTO_INCREMENT`;
-  else return '';
-}
-
-function checkUnique(fieldUnique) {
-  if (fieldUnique) return `\tUNIQUE`;
-  else return '';
-}
-
-function checkRequired(fieldRequired) {
-  if (fieldRequired) return `\tNOT NULL`;
-  else return '';
-}
-
-function checkDefault(fieldDefault) {
-  if (fieldDefault.length > 0) return `\tDEFAULT '${fieldDefault}'`;
-  else return '';
-}
-
-// loop through tables and create build script for each table
-for (const tableId in props.tables) {
-  parseSQLTable(props.tables[tableId]);
-}
 
   // if any tables have relations, aka foreign keys
   for (const tableId in foreignKeys) {
     // loop through the table's fields to find the particular relation
     foreignKeys[tableId].forEach((relationInfo, relationCount) => {
       // name of table making relation
-      const tableMakingRelation = props.tables[tableId].type;
+      const tableMakingRelation = tables[tableId].type;
       // get name of field making relation
       const fieldId = relationInfo.fieldMakingRelation;
-      const fieldMakingRelation = props.tables[tableId].fields[fieldId].name;
+      const fieldMakingRelation = tables[tableId].fields[fieldId].name;
       // get name of table being referenced
       const relatedTableId = relationInfo.relatedTable;
-      const relatedTable = props.tables[relatedTableId].type;
+      const relatedTable = tables[relatedTableId].type;
       // get name of field being referenced
       const relatedFieldId = relationInfo.relatedField;
-      const relatedField = props.tables[relatedTableId].fields[relatedFieldId].name;
+      const relatedField = tables[relatedTableId].fields[relatedFieldId].name;
       
       createTablesCode += `\nALTER TABLE \`${tableMakingRelation}\` ADD CONSTRAINT \`${tableMakingRelation}_fk${relationCount}\` FOREIGN KEY (\`${fieldMakingRelation}\`) REFERENCES \`${relatedTable}\`(\`${relatedField}\`);\n`;
     });
+  }
+  return createTablesCode; 
+
+  function createTableField(field) {
+    let fieldCode = ``;
+    fieldCode += `${tab}\`${field.name}\`${tab}${checkDataType(field.type)}`;
+    fieldCode += checkAutoIncrement(field.autoIncrement);
+    fieldCode += checkRequired(field.required);
+    fieldCode += checkUnique(field.unique);
+    fieldCode += checkDefault(field.defaultValue);
+    
+    if (field.primaryKey) {
+      primaryKey.push(field.name);
+    }
+    
+    if (field.relationSelected) {
+      const relationData = {
+        'relatedTable': field.relation.tableIndex,
+        'relatedField': field.relation.fieldIndex,
+        'fieldMakingRelation': field.fieldNum
+      };
+      if (foreignKeys[field.tableNum]) {
+        foreignKeys[field.tableNum].push(relationData);
+      } else {
+        foreignKeys[field.tableNum] = [relationData];
+      }
+    }
+    return fieldCode;
+  }
+  
+  function checkDataType(dataType) {
+    switch(dataType){
+      case 'String':
+      return `VARCHAR`;
+      case 'Number':
+      return `INT`;
+      case 'Boolean':
+      return `BOOLEAN`;
+      case 'ID':
+      return `VARCHAR`;
+    }
+  }
+  
+  function checkAutoIncrement(fieldAutoIncrement) {
+    if (fieldAutoIncrement) return `${tab}AUTO_INCREMENT`;
+    else return '';
+  }
+  
+  function checkUnique(fieldUnique) {
+    if (fieldUnique) return `${tab}UNIQUE`;
+    else return '';
+  }
+  
+  function checkRequired(fieldRequired) {
+    if (fieldRequired) return `${tab}NOT NULL`;
+    else return '';
+  }
+  
+  function checkDefault(fieldDefault) {
+    if (fieldDefault.length > 0) return `${tab}DEFAULT '${fieldDefault}'`;
+    else return '';
   }
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -30,6 +30,8 @@ app.use(express.static(path.join(__dirname, '../public')));
 app.post('/write-files', (req, res) => {
   const data = req.body; // data.data is state.tables from schemaReducer. See Navbar component
   const dateStamp = Date.now();
+  console.log('fields of table 0', data.data['0'].fields);
+  console.log('fields of table 1', data.data['1'].fields); 
 
   buildDirectories(dateStamp, () => {
 
@@ -56,7 +58,7 @@ app.post('/write-files', (req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log('Server Listening!');
+  console.log(`Server Listening to ${PORT}!`);
 });
 
 function buildDirectories(dateStamp, cb) {
@@ -87,7 +89,7 @@ function buildForMongo(data, dateStamp) {
 
 function buildForMySQL(data, dateStamp) {
   fs.writeFileSync(path.join(PATH, `build-files${dateStamp}/server/db/mysql_pool.js`), mysqlPool());
-  fs.writeFileSync(path.join(PATH, `build-files${dateStamp}/server/db/mysql_scripts.js`), parseMySQLTables());
+  fs.writeFileSync(path.join(PATH, `build-files${dateStamp}/server/db/mysql_scripts.js`), parseMySQLTables(data));
 }
 
 function deleteTempFiles(database, data, dateStamp, cb) {

--- a/server/index.js
+++ b/server/index.js
@@ -30,8 +30,6 @@ app.use(express.static(path.join(__dirname, '../public')));
 app.post('/write-files', (req, res) => {
   const data = req.body; // data.data is state.tables from schemaReducer. See Navbar component
   const dateStamp = Date.now();
-  console.log('fields of table 0', data.data['0'].fields);
-  console.log('fields of table 1', data.data['1'].fields); 
 
   buildDirectories(dateStamp, () => {
 


### PR DESCRIPTION
-fixed bug where tables were being distorted from the function that changed set's to arrays
-exported code is now tabbed correctly. Changed /t to ${tab} in all locations. This will create properly spaced code for the user
-MySQL code is now generated and exported correctly. 
-many to many is commented out. User cannot select many to many anymore. 