### PR TITLE
SQL Default and Varchar Fix

### DIFF
--- a/client/components/code/database-code/code-db-mysql-container.js
+++ b/client/components/code/database-code/code-db-mysql-container.js
@@ -105,7 +105,7 @@ const CodeDBSQLContainer = (props) => {
 
   function checkDefault(fieldDefault, dataType) {
     if (fieldDefault.length > 0) {
-      const defaultString = `${tab}DEFAULT `;
+      let defaultString = `${tab}DEFAULT `;
       if (dataType === 'String') defaultString += `'${fieldDefault}'`;
       else defaultString += fieldDefault;
       return defaultString;

--- a/client/components/code/database-code/code-db-mysql-container.js
+++ b/client/components/code/database-code/code-db-mysql-container.js
@@ -104,7 +104,12 @@ const CodeDBSQLContainer = (props) => {
   }
 
   function checkDefault(fieldDefault, dataType) {
-    if (fieldDefault.length > 0) return `${tab}DEFAULT '${fieldDefault}'`;
+    if (fieldDefault.length > 0) {
+      const defaultString = `${tab}DEFAULT `;
+      if (dataType === 'String') defaultString += `'${fieldDefault}'`;
+      else defaultString += fieldDefault;
+      return defaultString;
+    }
     return '';
   }
 

--- a/client/components/code/database-code/code-db-mysql-container.js
+++ b/client/components/code/database-code/code-db-mysql-container.js
@@ -51,10 +51,10 @@ const CodeDBSQLContainer = (props) => {
   function createSchemaField(field) {
     let fieldCode = ``;
     fieldCode += `${tab}\`${field.name}\`${tab}${checkDataType(field.type)}`;
-    fieldCode += checkDefault(field.defaultValue, field.type);
     fieldCode += checkAutoIncrement(field.autoIncrement);
     fieldCode += checkRequired(field.required);
     fieldCode += checkUnique(field.unique);
+    fieldCode += checkDefault(field.defaultValue, field.type);
 
     if (field.primaryKey) {
       primaryKey.push(field.name);
@@ -78,7 +78,7 @@ const CodeDBSQLContainer = (props) => {
   function checkDataType(dataType) {
     switch(dataType){
       case 'String':
-        return `VARCHAR`;
+        return `VARCHAR(255)`;
       case 'Number':
         return `INT`;
       case 'Boolean':
@@ -104,9 +104,7 @@ const CodeDBSQLContainer = (props) => {
   }
 
   function checkDefault(fieldDefault, dataType) {
-    if (dataType === 'String') return fieldDefault.length ? `(${fieldDefault})` : `(255)`;
     if (fieldDefault.length > 0) return `${tab}DEFAULT '${fieldDefault}'`;
-    if (dataType === 'Boolean' && !fieldDefault.length) return `${tab}DEFAULT 'true'`;
     return '';
   }
 

--- a/client/components/code/database-code/code-db-postgres-container.js
+++ b/client/components/code/database-code/code-db-postgres-container.js
@@ -102,7 +102,7 @@ const CodeDBPostgresSchemaContainer = (props) => {
 
   function checkDefault(fieldDefault, dataType) {
     if (fieldDefault.length > 0) {
-      const defaultString = `${tab}DEFAULT `;
+      let defaultString = `${tab}DEFAULT `;
       if (dataType === 'String') defaultString += `'${fieldDefault}'`;
       else defaultString += fieldDefault;
       return defaultString;

--- a/client/components/code/database-code/code-db-postgres-container.js
+++ b/client/components/code/database-code/code-db-postgres-container.js
@@ -101,7 +101,12 @@ const CodeDBPostgresSchemaContainer = (props) => {
   }
 
   function checkDefault(fieldDefault, dataType) {
-    if (fieldDefault.length > 0) return `${tab}DEFAULT '${fieldDefault}'`;
+    if (fieldDefault.length > 0) {
+      const defaultString = `${tab}DEFAULT `;
+      if (dataType === 'String') defaultString += `'${fieldDefault}'`;
+      else defaultString += fieldDefault;
+      return defaultString;
+    }
     return '';
   }
 

--- a/client/components/code/database-code/code-db-postgres-container.js
+++ b/client/components/code/database-code/code-db-postgres-container.js
@@ -53,9 +53,9 @@ const CodeDBPostgresSchemaContainer = (props) => {
   function createSchemaField(field) {
     let fieldCode = ``;
     fieldCode += `${tab}"${field.name}"${tab}${checkDataType(field.type, field.autoIncrement)}`;
-    fieldCode += checkDefault(field.defaultValue, field.type);
     fieldCode += checkRequired(field.required);
     fieldCode += checkUnique(field.unique);
+    fieldCode += checkDefault(field.defaultValue, field.type);
 
     if (field.primaryKey) {
       primaryKey.push(field.name);
@@ -101,7 +101,6 @@ const CodeDBPostgresSchemaContainer = (props) => {
   }
 
   function checkDefault(fieldDefault, dataType) {
-    if (dataType === 'String' && fieldDefault.length) return `(${fieldDefault})`;
     if (fieldDefault.length > 0) return `${tab}DEFAULT '${fieldDefault}'`;
     return '';
   }

--- a/client/components/schema/schema.css
+++ b/client/components/schema/schema.css
@@ -5,7 +5,7 @@
   /* min-width: 750px;  */
   min-height: 450px;
   height: calc(100vh - 98px);
-  border: 1px solid black;
+  /* border: 1px solid black; */
   position: relative;
 }
 

--- a/server/create_file_func/mysql_scripts.js
+++ b/server/create_file_func/mysql_scripts.js
@@ -65,10 +65,10 @@ function parseSQLTables(tables) {
   function createTableField(field) {
     let fieldCode = ``;
     fieldCode += `${tab}\`${field.name}\`${tab}${checkDataType(field.type)}`;
-    fieldCode += checkDefault(field.defaultValue, field.type);
     fieldCode += checkAutoIncrement(field.autoIncrement);
     fieldCode += checkRequired(field.required);
     fieldCode += checkUnique(field.unique);
+    fieldCode += checkDefault(field.defaultValue, field.type);
 
     if (field.primaryKey) {
       primaryKey.push(field.name);
@@ -92,7 +92,7 @@ function parseSQLTables(tables) {
   function checkDataType(dataType) {
     switch(dataType){
       case 'String':
-      return `VARCHAR`;
+      return `VARCHAR(255)`;
       case 'Number':
       return `INT`;
       case 'Boolean':
@@ -118,9 +118,7 @@ function parseSQLTables(tables) {
   }
 
   function checkDefault(fieldDefault, dataType) {
-    if (dataType === 'String') return fieldDefault.length ? `(${fieldDefault})` : `(255)`;
     if (fieldDefault.length > 0) return `${tab}DEFAULT '${fieldDefault}'`;
-    if (dataType === 'Boolean' && !fieldDefault.length) return `${tab}DEFAULT 'true'`;
     return '';
   }
 }

--- a/server/create_file_func/mysql_scripts.js
+++ b/server/create_file_func/mysql_scripts.js
@@ -118,7 +118,12 @@ function parseSQLTables(tables) {
   }
 
   function checkDefault(fieldDefault, dataType) {
-    if (fieldDefault.length > 0) return `${tab}DEFAULT '${fieldDefault}'`;
+    if (fieldDefault.length > 0) {
+      const defaultString = `${tab}DEFAULT `;
+      if (dataType === 'String') defaultString += `'${fieldDefault}'`;
+      else defaultString += fieldDefault;
+      return defaultString;
+    }
     return '';
   }
 }

--- a/server/create_file_func/mysql_scripts.js
+++ b/server/create_file_func/mysql_scripts.js
@@ -119,7 +119,7 @@ function parseSQLTables(tables) {
 
   function checkDefault(fieldDefault, dataType) {
     if (fieldDefault.length > 0) {
-      const defaultString = `${tab}DEFAULT `;
+      let defaultString = `${tab}DEFAULT `;
       if (dataType === 'String') defaultString += `'${fieldDefault}'`;
       else defaultString += fieldDefault;
       return defaultString;

--- a/server/create_file_func/postgresql_scripts.js
+++ b/server/create_file_func/postgresql_scripts.js
@@ -93,7 +93,12 @@ function parsePostgresTables(tables) {
   }
 
   function checkDefault(fieldDefault, dataType) {
-    if (fieldDefault.length > 0) return `${tab}DEFAULT '${fieldDefault}'`;
+    if (fieldDefault.length > 0) {
+      const defaultString = `${tab}DEFAULT `;
+      if (dataType === 'String') defaultString += `'${fieldDefault}'`;
+      else defaultString += fieldDefault;
+      return defaultString;
+    }
     return '';
   }
 

--- a/server/create_file_func/postgresql_scripts.js
+++ b/server/create_file_func/postgresql_scripts.js
@@ -94,7 +94,7 @@ function parsePostgresTables(tables) {
 
   function checkDefault(fieldDefault, dataType) {
     if (fieldDefault.length > 0) {
-      const defaultString = `${tab}DEFAULT `;
+      let defaultString = `${tab}DEFAULT `;
       if (dataType === 'String') defaultString += `'${fieldDefault}'`;
       else defaultString += fieldDefault;
       return defaultString;

--- a/server/create_file_func/postgresql_scripts.js
+++ b/server/create_file_func/postgresql_scripts.js
@@ -44,9 +44,9 @@ function parsePostgresTables(tables) {
   function createSchemaField(field) {
     let fieldCode = ``;
     fieldCode += `${tab}"${field.name}"${tab}${checkDataType(field.type, field.autoIncrement)}`;
-    fieldCode += checkDefault(field.defaultValue, field.type);
     fieldCode += checkRequired(field.required);
     fieldCode += checkUnique(field.unique);
+    fieldCode += checkDefault(field.defaultValue, field.type);
 
 
     if (field.primaryKey) {
@@ -93,7 +93,6 @@ function parsePostgresTables(tables) {
   }
 
   function checkDefault(fieldDefault, dataType) {
-    if (dataType === 'String' && fieldDefault.length) return `(${fieldDefault})`;
     if (fieldDefault.length > 0) return `${tab}DEFAULT '${fieldDefault}'`;
     return '';
   }


### PR DESCRIPTION
Previous PR edited default values which would cause errors when entering into a database. For example, if you made a table "Test" with an unique id, and a field called "defaultTest" that was a String with a default value of "hi", you'd get the following auto generated code:

CREATE TABLE "Test" (
  "id"  serial  UNIQUE,
   "defaultTest"  varchar(hi),
   CONSTRAINT Test_pk PRIMARY KEY ("id")
 ) WITH (
   OIDS=FALSE
 );

This would give the following error: 
ERROR:  syntax error at or near "hi"
LINE 3:   "defaultTest"  varchar(hi),

Changed the code to instead make the following which will successfully make a table:
CREATE TABLE "Test" (
  "id"  serial  UNIQUE,
  "defaultTest"  varchar  DEFAULT 'hi',
  CONSTRAINT Test_pk PRIMARY KEY ("id")
) WITH (
  OIDS=FALSE
);

Also made the code check if the type was a string, if so, it put strings around the default value. Otherwise it would not put strings around. Lastly, made MySQL varchar back to 255 so it wouldn't break upon creation. 