### PR TITLE
Instead of `mysql` use `promise-mysql`

### DIFF
--- a/utl/create_file_func/sql_pool.js
+++ b/utl/create_file_func/sql_pool.js
@@ -3,7 +3,7 @@ function sqlPool(database) {
 
   // if MySQL, create MySQL specific code
   if (database === 'MySQL') {
-    query += `const mysql = require('mysql')
+    query += `const mysql = require('promise-mysql')
 
 const pool = mysql.createPool({
   connectionLimit: 10,


### PR DESCRIPTION
In graphql browser when I execute the query, I am getting an error saying "pool.query(...).then is not a function"
because I had to use the `promise-mysql` to solve it.